### PR TITLE
docs: fix url-deftypes

### DIFF
--- a/docs/modules/db/partials/deftypes.adoc
+++ b/docs/modules/db/partials/deftypes.adoc
@@ -1,7 +1,7 @@
 [#deftype]
 == Defined Types
 
-:url-deftypes: https://github.com/rackslab/racksdb/blob/main/racksdb/types
+:url-deftypes: https://github.com/rackslab/racksdb/blob/main/racksdb/dtypes
 
 [cols="2a,2a,1l,3a"]
 |===


### PR DESCRIPTION
Module types was renamed dtypes.

This should fix broken links at https://docs.rackslab.io/racksdb/db/structure.html#deftype.