### PR TITLE
feat(schema): add NodeTypeGpu object

### DIFF
--- a/docs/modules/db/partials/objects.adoc
+++ b/docs/modules/db/partials/objects.adoc
@@ -453,6 +453,12 @@ Library class type: `RacksDBNodeType`
 
 |{symbol-seq}{nbsp}xref:#obj-nodetypenetif[{symbol-obj}{nbsp}NodeTypeNetif]
 |[.grey]#-#
+
+|gpu
+|List of GPUs of the node.
+
+|{symbol-seq}{nbsp}xref:#obj-nodetypegpu[{symbol-obj}{nbsp}NodeTypeGpu]
+|[.grey]#-#
 |===
 
 [#obj-nodetypecpu]
@@ -487,6 +493,35 @@ Library class type: `RacksDBNodeTypeCpu`
 |The number of cores per socket.
 
 |int
+|[.green]#icon:check[]#
+|===
+
+[#obj-nodetypegpu]
+=== NodeTypeGpu
+
+Library class type: `RacksDBNodeTypeGpu`
+
+.Properties
+[cols="{tbl-obj-props-cols-specs}"]
+|===
+|Property|Description|Type|Required
+
+|model
+|The GPU model name.
+
+|str
+|[.green]#icon:check[]#
+
+|specs
+|URL to GPU specsheet.
+
+|str
+|[.grey]#-#
+
+|memory
+|The amount of memory per GPU.
+
+|xref:#deftype-bytes[{symbol-deftype}{nbsp}~bytes]
 |[.green]#icon:check[]#
 |===
 

--- a/docs/modules/usage/attachments/openapi.yml
+++ b/docs/modules/usage/attachments/openapi.yml
@@ -217,6 +217,9 @@ components:
         cpu:
           $ref: '#/components/schemas/NodeTypeCpu'
           description: CPU configuration of the node.
+        gpu:
+          $ref: '#/components/schemas/NodeTypeGpu'
+          description: List of GPUs of the node.
         height:
           description: Height of the node.
           example: 2
@@ -267,6 +270,21 @@ components:
         specs:
           description: URL to CPU specsheet.
           example: https://sipearl.com/en
+          type: string
+      type: object
+    NodeTypeGpu:
+      properties:
+        memory:
+          description: The amount of memory per GPU.
+          example: 137438953472
+          type: integer
+        model:
+          description: The GPU model name.
+          example: AMD Instinct MI250
+          type: string
+        specs:
+          description: URL to GPU specsheet.
+          example: https://www.amd.com/fr/products/server-accelerators/instinct-mi250
           type: string
       type: object
     NodeTypeNetif:

--- a/schema/racksdb.yml
+++ b/schema/racksdb.yml
@@ -70,6 +70,10 @@ _objects:
         type: list[:NodeTypeNetif]
         description: List of network interfaces of the node.
         optional: true
+      gpu:
+        type: list[:NodeTypeGpu]
+        description: List of GPUs of the node.
+        optional: true
   NodeTypeCpu:
     properties:
       model:
@@ -124,6 +128,21 @@ _objects:
         type: ~bytes
         description: The bandwidth (per second) of the network interface.
         example: 100Gb
+  NodeTypeGpu:
+    properties:
+      model:
+        type: str
+        description: The GPU model name.
+        example: AMD Instinct MI250
+      specs:
+        type: str
+        description: URL to GPU specsheet.
+        optional: true
+        example: https://www.amd.com/fr/products/server-accelerators/instinct-mi250
+      memory:
+        type: ~bytes
+        description: The amount of memory per GPU.
+        examples: 128GB
   StorageEquipmentType:
     properties:
       id:


### PR DESCRIPTION
This is a tentative to add support of GPUs to the nodes.

Usage example:
```
model: NVIDIA DGX A100 320GB
height: 6u
width: 1
specs: https://docs.nvidia.com/dgx/dgxa100-user-guide/introduction-to-dgxa100.html#dgx-a100-models-and-component-descriptions
cpu:
  sockets: 2
  model: AMD EPYC 7742
  specs: https://www.amd.com/en/products/cpu/amd-epyc-7742
  cores: 64
ram:
  dimm: 16
  size: 64GB
gpu:
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
  - model: A100
    memory: 40GB
storage:
  - type: nvme
    model: NVMe M.2 SSD
    size: 1.92TB
  - type: nvme
    model: NVMe U.2 SED
    size: 14TB
netifs:
  - type: ethernet
    bandwidth: 1Gb
  - type: infiniband
    bandwidth: 200Gb
  - type: infiniband
    bandwidth: 200Gb
```