### PR TITLE
feat(draw): add color to equipment and rack types

### DIFF
--- a/racksdb/drawers/infrastructure.py
+++ b/racksdb/drawers/infrastructure.py
@@ -109,7 +109,11 @@ class InfrastructureDrawer(Drawer):
         equipment_height = int(equipment.type.height * self.RACK_U_HEIGHT)
 
         # draw equipment background
-        self.ctx.set_source_rgb(0.6, 0.6, 0.6)  # grey
+        self.ctx.set_source_rgb(
+            equipment.type.color[0]/255,
+            equipment.type.color[1]/255,
+            equipment.type.color[2]/255
+        )
         self.ctx.set_line_width(1)
         self.ctx.rectangle(
             tl.x,
@@ -167,7 +171,11 @@ class InfrastructureDrawer(Drawer):
         self.ctx.stroke()
 
         # draw rack panes
-        self.ctx.set_source_rgb(0, 0, 0)  # black
+        self.ctx.set_source_rgb(
+            rack.type.color[0]/255,
+            rack.type.color[1]/255,
+            rack.type.color[2]/255
+        )
         self.ctx.rectangle(
             dl.x,
             dl.y - rack_height,

--- a/racksdb/drawers/room.py
+++ b/racksdb/drawers/room.py
@@ -68,7 +68,11 @@ class RoomDrawer(Drawer):
         rack_width = int(rack.type.width * self.SCALE)
         rack_height = int(rack.type.depth * self.SCALE)
         # draw rack frame
-        self.ctx.set_source_rgb(0.4, 0.4, 0.4)  # grey
+        self.ctx.set_source_rgb(
+            rack.type.color[0]/255,
+            rack.type.color[1]/255,
+            rack.type.color[2]/255
+        )
         self.ctx.set_line_width(1)
         self.ctx.rectangle(
             tl.x,

--- a/schema/racksdb.yml
+++ b/schema/racksdb.yml
@@ -74,6 +74,11 @@ _objects:
         type: list[:NodeTypeGpu]
         description: List of GPUs of the node.
         optional: true
+      color:
+        type: list[int]
+        description: Equipment background [red, green, blue]
+        default: [153,153,153]
+        example: [255,122,0]
   NodeTypeCpu:
     properties:
       model:
@@ -176,6 +181,11 @@ _objects:
         type: list[:StorageEquipmentTypeNetif]
         description: List of network devices in the storage equipment.
         optional: true
+      color:
+        type: list[int]
+        description: Equipment background [red, green, blue]
+        default: [153,153,153]
+        example: [255,122,0]
   StorageEquipmentTypeDisk:
     properties:
       type:
@@ -235,6 +245,11 @@ _objects:
         type: list[:NetworkEquipmentTypeNetif]
         description: List of network interfaces on this network equipment.
         optional: true
+      color:
+        type: list[int]
+        description: Equipment background [red, green, blue]
+        default: [153,153,153]
+        example: [255,122,0]
   NetworkEquipmentTypeNetif:
     properties:
       type:
@@ -274,6 +289,11 @@ _objects:
         type: ~rack_height
         description: Number of U slots available in the rack.
         example: 42u
+      color:
+        type: list[int]
+        description: Rack background [red, green, blue]
+        default: [51,51,51]
+        example: [255,122,0]
   Datacenter:
     properties:
       name:


### PR DESCRIPTION
This is an attempt to add color to equipment and rack types.

The schema is updated with a new property `color` for `NodeType` and `RackType`. The default value is the one that was defined by default in the code.

For NodeType, this will color the background when drawing the infrastructure. For RackType, this will color the frame when drawing the room and the panes when drawing the infrastructure.

While the code uses `set_source_rgb(red: float, green: float, blue: float)`, I defined the type as `list[int]` where one should define the color as [red, green, blue] with a value in the range `0-255`. My first attempt was to use floats, but I found it user-unfriendly. Maybe a string in HEX format like `#FF7A00` might even be better?

There is no test of the integer value (one can use `12345678`), nor test of the length of the list (yet the code will only use the first three items anyway).

If you see an interest in this feature, we can discuss it here. I will update the documentation accordingly.