### PR TITLE
docs(examples): fix typo in GPU nodes name

### DIFF
--- a/examples/db/infrastructures/mercury.yml
+++ b/examples/db/infrastructures/mercury.yml
@@ -38,7 +38,7 @@ layout:
     type: dellr550
     slot: 8
     tags: [servers]
-  - name: megpu[0001-008]
+  - name: megpu[0001-0008]
     type: bullsx440a5
     slot: 20
     tags: [ia, gpu]


### PR DESCRIPTION
Fix the padding length mismatch that prevents to draw the infrastructure.