### PR TITLE
fix(draw): display row front even when reversed

### DIFF
--- a/racksdb/drawers/infrastructure.py
+++ b/racksdb/drawers/infrastructure.py
@@ -59,9 +59,14 @@ class InfrastructureDrawer(Drawer):
         dl = self._rack_row_dl(row)
 
         # Sum the width of all racks in row before the current rack
-        for row_rack in rack.row.racks:
-            if row_rack.slot < rack.slot:
-                dl.x += int(row_rack.type.width * self.SCALE) + self.RACK_SPACING
+        if rack.row.reversed:
+          for row_rack in rack.row.racks:
+              if row_rack.slot > rack.slot:
+                  dl.x += int(row_rack.type.width * self.SCALE) + self.RACK_SPACING
+        else:
+          for row_rack in rack.row.racks:
+              if row_rack.slot < rack.slot:
+                  dl.x += int(row_rack.type.width * self.SCALE) + self.RACK_SPACING
         dl.y += self.RACK_LABEL_OFFSET + self.RACK_OFFSET
         return dl
 


### PR DESCRIPTION
With data center aisle containment, one row might be reversed relative to the other. This is correctly represented with `RacksRow.reversed=true` when drawing the room, but not when drawing the infrastructure. In the latter, the drawing will display the front of one row and the rear of the other.

Fix this by displaying the racks in the correct order to always display the row front in the infrastructure.