### PR TITLE
fix(draw): scalable racks labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to
     even if they do not contain infrastructure equipment. Other racks are
     represented when set to true. It is false by default (#61).
   - Add support for optional alpha channel in `~hexcolor` defined type (#65).
+  - Make racks labels scalable to avoid exceeding rack width in infrastructure
+    diagrams (#69).
 - pkg:
   - Add dependency on PyGObject python library (used to call Pango library).
   - Add optional dependency on requests-toolbelt python library on web variant

--- a/racksdb/drawers/infrastructure.py
+++ b/racksdb/drawers/infrastructure.py
@@ -441,7 +441,7 @@ class InfrastructureDrawer(Drawer):
         # write rack name
         self.ctx.move_to(dl.x, dl.y - rack_height - self.parameters.rack.offset)
         self.ctx.set_source_rgba(0, 0, 0, 1)  # black
-        self._print_text(f"rack {rack.name}")
+        self._print_text(f"rack {rack.name}", max_width=self._rack_width(rack))
 
         colorset = self._find_rack_colorset(rack)
 


### PR DESCRIPTION
Make racks labels scalable to avoid exceeding rack width in infrastructure diagrams.

fix #69