### PR TITLE
fix(front): npm audit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to
   - Wrong APT sources file extension in quickstart guide.
   - Path of system packages examples directory in quickstart guide.
 - ui: Update bundled dependencies to fix security issues CVE-2024-39338 (axios),
-  CVE-2024-4068 (braces), CVE-2024-31207, CVE-2024-45812, CVE-2024-45811 (vite),
-  CVE-2024-6783 (vue-template-compiler), CVE-2024-37890 (ws), CVE-2024-21538
-  (cross-spawn), CVE-2024-4067 (micromatch), CVE-2024-47068 (rollup).
+  CVE-2024-4068 (braces), CVE-2024-31207, CVE-2024-45812, CVE-2024-45811,
+  CVE-2025-24010 (vite), CVE-2024-6783 (vue-template-compiler), CVE-2024-37890
+  (ws), CVE-2024-21538 (cross-spawn), CVE-2024-4067 (micromatch), CVE-2024-47068
+  (rollup), CVE-2024-55565 (nanoid).
 - pkg: Add missing dependency on _setuptools_ for `pkg_resources` module.
 
 ### Removed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3051,9 +3051,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -4661,9 +4661,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
+      "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "prettier-plugin-tailwindcss": "^0.5.5",
     "tailwindcss": "^3.3.3",
     "typescript": "~5.2.0",
-    "vite": "^4.5.2",
+    "vite": "^4.5.9",
     "vitest": "^0.34.4",
     "vue-tsc": "^2.0.29"
   }


### PR DESCRIPTION
Fix the following security issues in dependencies:

  nanoid  <3.3.8
  Severity: moderate
  Predictable results in nanoid generation when given non-integer values
  - https://github.com/advisories/GHSA-mwcw-c2x4-8c55

  vite  <=4.5.5
  Severity: moderate
  Websites were able to send any requests to the development server and
  read the response in vite - https://github.com/advisories/GHSA-vg6x-rcgg-rjx6