### PR TITLE
chore(ci): update ubuntu/python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: "ubuntu-20.04"
             python-version: "3.6"
+          - os: "ubuntu-22.04"
+            python-version: "3.7"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
On Github, ubuntu-latest is now ubuntu-24.04 and does not support 3.7 anymore. Force ubuntu-22.04 for 3.7, and add 3.13 on ubuntu-latest.