### PR TITLE
fix(ui): limit specs links size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,13 @@ and this project adheres to
     option of `racksdb-web`.
   - Log critical error instead of crashing when `racksdb-web` is unable to load
     schema or database (#110).
-- ui: Update bundled dependencies to fix security issues CVE-2024-39338 (axios),
-  CVE-2024-4068 (braces), CVE-2024-31207, CVE-2024-45812, CVE-2024-45811,
-  CVE-2025-24010 (vite), CVE-2024-6783 (vue-template-compiler), CVE-2024-37890
-  (ws), CVE-2024-21538 (cross-spawn), CVE-2024-4067 (micromatch), CVE-2024-47068
-  (rollup), CVE-2024-55565 (nanoid).
+- ui:
+  - Limit specs links size in equipment type modal (#76).
+  - Update bundled dependencies to fix security issues CVE-2024-39338 (axios),
+    CVE-2024-4068 (braces), CVE-2024-31207, CVE-2024-45812, CVE-2024-45811,
+    CVE-2025-24010 (vite), CVE-2024-6783 (vue-template-compiler), CVE-2024-37890
+    (ws), CVE-2024-21538 (cross-spawn), CVE-2024-4067 (micromatch),
+    CVE-2024-47068 (rollup), CVE-2024-55565 (nanoid).
 - pkg: Fix `pkg_resources` API deprecation error by using importlib module and
   `importlib_metadata` external backport library for Python < 3.8 (#104).
 

--- a/frontend/src/components/EquipmentTypeModal.vue
+++ b/frontend/src/components/EquipmentTypeModal.vue
@@ -14,6 +14,12 @@ import type {
 } from '@/composables/RacksDBAPI'
 import { Dialog, DialogPanel } from '@headlessui/vue'
 
+function strTruncateLimit(str: string, limit: number): string {
+  if (str.length < limit) return str
+  const edge_limit = limit / 2
+  return str.slice(0, edge_limit) + '...' + str.slice(-edge_limit)
+}
+
 defineProps({
   showModal: Boolean,
   modalContent: {
@@ -61,8 +67,8 @@ defineProps({
               ><a
                 :href="modalContent.specs"
                 target="_blank"
-                class="font-bold hover:text-purple-700 capitalize"
-                >{{ modalContent.specs }}</a
+                class="font-bold hover:text-purple-700"
+                >{{ strTruncateLimit(modalContent.specs, 50) }}</a
               ></span
             >
           </p>
@@ -82,8 +88,8 @@ defineProps({
               ><a
                 :href="modalContent.cpu.specs"
                 target="_blank"
-                class="font-bold hover:text-purple-700 capitalize"
-                >{{ modalContent.cpu.specs }}</a
+                class="font-bold hover:text-purple-700"
+                >{{ strTruncateLimit(modalContent.specs, 50) }}</a
               ></span
             >
           </p>


### PR DESCRIPTION
Limit specs links size to 50 chars max.

fix #76