### PR TITLE
tests: skip WebAppEndpoints tests w/o UI dir

### DIFF
--- a/racksdb/tests/lib/common.py
+++ b/racksdb/tests/lib/common.py
@@ -54,4 +54,7 @@ def db_one_file_path():
 def ui_path():
     # This path does not contain the full UI application but enough files to
     # test.
-    return Path(CURRENT_DIR).joinpath("../../../frontend/public")
+    return _first_path(
+        [Path(CURRENT_DIR).joinpath("../../../frontend/public")],
+        "Unable to find UI public directory to run tests",
+    )

--- a/racksdb/tests/web/test_app.py
+++ b/racksdb/tests/web/test_app.py
@@ -59,7 +59,10 @@ class TestRacksDBWebApp(unittest.TestCase):
 class TestRacksDBWebAppEndpoints(unittest.TestCase):
 
     def setUp(self):
-        self.app = RacksDBWebApp(CMD_BASE_ARGS + ["--with-ui", str(ui_path())])
+        try:
+            self.app = RacksDBWebApp(CMD_BASE_ARGS + ["--with-ui", str(ui_path())])
+        except FileNotFoundError as err:
+            self.skipTest(err)
         self.app.config.update(
             {
                 "TESTING": True,


### PR DESCRIPTION
If unable to find UI public directory, gently skip RacksDBWebAppEndPoints tests. This is done to avoid these tests to fail during deb packages build as frontend/public directory is not present in tests directory in this environment.