### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ on:
     - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rackslab/RacksDB/security/code-scanning/1](https://github.com/rackslab/RacksDB/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the root of the workflow file or within the specific job (`pre-commit`). Based on the actions used (e.g., `actions/checkout`, `actions/setup-python`, and `pre-commit/action`), the workflow likely requires read-only access to repository contents. Therefore, the `permissions` can be set to `contents: read`. 

The changes should be made in the `.github/workflows/pre-commit.yml` file by adding the `permissions` key at the root level of the workflow or within the `pre-commit` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
