### PR TITLE
ci: add OS integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,12 @@ permissions:
   contents: read
 
 jobs:
-  tests:
-    name: Python tests
+  python_tests:
+    name: Python unit tests
     strategy:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
-          - os: "ubuntu-22.04"
-            python-version: "3.7"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -35,61 +30,179 @@ jobs:
       - name: Install tests dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libcairo2-dev libgirepository1.0-dev libpango1.0-dev
+          sudo apt-get install -y build-essential libcairo2-dev libgirepository-1.0-dev libgirepository-2.0-dev libpango1.0-dev
           python -m pip install --upgrade pip
 
-      # New version of PyGObject 3.52.1 depends on libgirepository-2.0-dev,
-      # which is available in ubuntu >= 24.04 only.
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt-get install -y libgirepository-2.0-dev
-
       - name: Install application with its dependencies
-        if: ${{ matrix.python-version != '3.6' }}
         run: |
           pip install . .[web] .[tests]
 
-      # Unfortunately, pip and setuptools in Python 3.6 do not fully support
+      - name: Run tests
+        run: pytest
+
+  os_rpm_tests:
+    name: OS integration tests (rpm)
+    strategy:
+      fail-fast: false
+      matrix:
+        envs:
+        - container: rockylinux/rockylinux:8
+          epel: 8
+          repo: powertools
+          rackslab-repo: el8
+        - container: rockylinux/rockylinux:9
+          epel: 9
+          repo: crb
+          rackslab-repo: el9
+        - container: fedora:42
+          rackslab-repo: fc42
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.envs.container }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable EPEL repository (Rocky Linux)
+        if: ${{ startsWith(matrix.envs.container, 'rockylinux') }}
+        run: |
+          dnf -y install 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled ${{ matrix.envs.repo }}
+          dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{ matrix.envs.epel }}.noarch.rpm
+
+      - name: Add Rackslab repository
+        run: |
+          curl --silent https://pkgs.rackslab.io/keyring.asc --output /etc/pki/rpm-gpg/RPM-GPG-KEY-Rackslab
+          cat <<EOF > /etc/yum.repos.d/rackslab.repo
+          [rackslab]
+          name=Rackslab
+          baseurl=https://pkgs.rackslab.io/rpm/${{ matrix.envs.rackslab-repo }}/main/x86_64/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rackslab
+          EOF
+
+      - name: Install tests dependencies
+        run: |
+          dnf -y install \
+            cairo-devel \
+            gcc \
+            pango \
+            pkg-config \
+            python3-cairo \
+            python3-clustershell \
+            python3-devel \
+            python3-gobject \
+            python3-flask \
+            python3-importlib-metadata \
+            python3-parameterized \
+            python3-pip \
+            python3-pytest \
+            python3-PyYAML \
+            python3-requests \
+            python3-requests-toolbelt \
+            python3-rfl-build \
+            python3-rfl-log
+
+      # Python cached_property is required with Python 3.6 on Rocky Linux 8.
+      - name: Install cached property (Rocky Linux 8)
+        if: ${{ matrix.envs.container == 'rockylinux/rockylinux:8' }}
+        run: |
+          dnf -y install python3-cached_property
+
+      # Unfortunately, pip and setuptools in RHEL8 do not fully support
       # PEP517 pyproject.toml. As a workaround for this version, the setup.py
       # script provided by RFL.build package is copied and executed.
       #
-      # Some dependencies are pre-installed to add version constraints, in order
-      # to force installation of old versions compatible with Python 3.6.
-      #
-      # Some RacksDB optional dependencies are declared in extra packages.
-      # This is not supported by setup.py script from RFL.build. As a workaround
-      # these dependencies are installed manually afterwhile.
-      - name: Install application with its dependencies (Python 3.6)
-        if: ${{ matrix.python-version == '3.6' }}
+      # Latest version of setuptools build wheels following PEP-491 naming
+      # conventions (eg. RFL.core becomes rfl-core) published with this name on
+      # PyPI but old versions of setuptools do not support this naming
+      # equivalence. For this reason, RFL dependencies are renamed with sed in
+      # pyproject.toml so old versions of setuptools can find the wheels on
+      # PyPI.
+      - name: Install RFL.build setup wrapper (Rocky Linux 8)
+        if: ${{ matrix.envs.container == 'rockylinux/rockylinux:8' }}
         run: |
-          echo "::notice::Installing RFL.build"
-          pip install RFL.build
-          echo "::notice::Installing PyYAML (old version)"
-          pip install PyYAML==5.4.1
-          echo "::notice::Installing PyGObject (old version)"
-          pip install "PyGObject<3.43.0"
-          echo "::notice::Installing Werkzeug (old version)"
-          pip install "Werkzeug<0.13"
-          echo "::notice::Installing Flask (old version)"
-          pip install "flask<1.0"
-          echo "::notice::Installing requests-toolbelt (old version)"
-          pip install requests-toolbelt==0.9.1
-          echo "::notice::Installing parameterized"
-          pip install parameterized
+          cp -v /usr/lib/python3.6/site-packages/rfl/build/scripts/setup setup.py
+          sed -i 's/RFL\./rfl-/' pyproject.toml
 
-          cp -v ${Python3_ROOT_DIR}/lib/python3.6/site-packages/rfl/build/scripts/setup setup.py
-          python3 setup.py install
+      - name: Install application
+        run: pip3 install -e .
 
-          echo "::notice::Installing optional dependencies required for tests"
-          pip install pytest
+      - name: Run tests
+        run: pytest-3
 
-      # The cached_property decorator is integrated in Python 3.8+. For older
-      # versions, install cached_property external library.
-      # On Python 3.8+, RacksDB uses importlib.metadata in standard library to
-      # retrieve the version of the package. For older versions, install
-      # importlib_metadata external backport library, and explicitely force the
-      # old version available in RHEL8.
-      - if: ${{ matrix.python-version == '3.6' || matrix.python-version == '3.7' }}
-        run: pip install cached_property "importlib-metadata==0.23"
+  os_deb_tests:
+    name: OS integration tests (deb)
+    strategy:
+      fail-fast: false
+      matrix:
+        envs:
+        - container: debian:oldstable
+          rackslab-repo: bookworm
+        - container: debian:stable
+          rackslab-repo: trixie
+        - container: debian:testing
+          rackslab-repo: forky
+        - container: debian:unstable
+          rackslab-repo: sid
+        - container: ubuntu:noble
+          rackslab-repo: ubuntu24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.envs.container }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add Rackslab repository
+        run: |
+          apt update
+          apt install -y ca-certificates curl gpg
+          curl -sS https://pkgs.rackslab.io/keyring.asc | gpg --dearmor | tee /usr/share/keyrings/rackslab.gpg > /dev/null
+          cat <<EOF > /etc/apt/sources.list.d/rackslab.sources
+          Types: deb
+          URIs: https://pkgs.rackslab.io/deb
+          Suites: ${{ matrix.envs.rackslab-repo }}
+          Components: main
+          Architectures: amd64
+          Signed-By: /usr/share/keyrings/rackslab.gpg
+          EOF
+
+      - name: Install tests dependencies
+        run: |
+          apt update
+          apt install -y \
+            build-essential \
+            libcairo2-dev \
+            libpango1.0-dev \
+            python3-clustershell \
+            python3-cairo \
+            python3-flask \
+            python3-gi \
+            python3-gi-cairo \
+            python3-parameterized \
+            python3-pip \
+            python3-pytest \
+            python3-yaml \
+            python3-requests \
+            python3-requests-toolbelt \
+            python3-rfl-log \
+            python3-venv
+
+      # Only libgirepository1.0-dev is available in Debian oldstable.
+      - name: Install libgirepository (Debian oldstable)
+        if: ${{ matrix.envs.container == 'debian:oldstable' }}
+        run: |
+          apt install -y libgirepository1.0-dev
+
+      # New version of PyGObject 3.52.1 depends on libgirepository-2.0-dev.
+      - name: Install libgirepository (except on Debian oldstable)
+        if: ${{ matrix.envs.container != 'debian:oldstable' }}
+        run: |
+          apt install -y libgirepository-1.0-dev libgirepository-2.0-dev
+
+      - name: Install application
+        run: |
+          python3 -m venv --system-site-packages ~/venv
+          ~/venv/bin/pip install -e .
 
       - name: Run tests
         run: pytest


### PR DESCRIPTION
To cover all supported Linux distributions with old versions of Python, introduce OS integrations tests complementary to standard Python tests.