### PR TITLE
fix(front): fit datacenters map zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 - cli: Add auto-paging to `dump`, `schema` and all view commands (#138).
+- web: Adjust datacenters map zoom level to fit their markers locations (#78).
 - docs:
   - Mention support of Fedora 42.
   - Mention support of Debian 14 _« forky »_

--- a/frontend/src/views/DatacentersView.vue
+++ b/frontend/src/views/DatacentersView.vue
@@ -54,9 +54,11 @@ function datacentersMapConfig() {
   // Configuration of the map
   const map = L.map(mapContainer.value).setView([averageLatitude, averageLongitude], 5)
   L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
   }).addTo(map)
+
+  // Prepare bounds to fit all markers
+  const bounds = L.latLngBounds([])
 
   // Add a marker on a map if the datacenter has coordinates
   datacenters.value.forEach((datacenter) => {
@@ -80,6 +82,7 @@ function datacentersMapConfig() {
     let marker = L.marker([datacenter.location.latitude, datacenter.location.longitude], {
       icon: purpleIcon
     }).addTo(map)
+    bounds.extend([datacenter.location.latitude, datacenter.location.longitude])
     marker.bindPopup(
       `<div class="text-center max-h-30">
         <a class="appearance-none" href="${datacenterRoute.fullPath}">
@@ -90,6 +93,9 @@ function datacentersMapConfig() {
       </div>`
     )
   })
+
+  // Adjust the map view to include all markers
+  map.fitBounds(bounds, { padding: [10, 10] })
 }
 
 onMounted(async () => {


### PR DESCRIPTION
Adjust datacenters map zoom level to fit actual markers locations, instead of arbitrary hard-coded zoom level.

fix #78