### PR TITLE
docs: fix system dep package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 - pkgs: Bump minimal requirement on `RFL.log` >= 1.6.0.
 - docs: Reword s/modelize/modeling/.
 
+### Fixed
+- docs: System dependency package name in quickstart guide when installing from
+  PyPI and from source (#131).
+
 ### Removed
 - docs: Drop support of Fedora 40.
 

--- a/docs/modules/install/pages/quickstart.adoc
+++ b/docs/modules/install/pages/quickstart.adoc
@@ -242,10 +242,7 @@ To install RacksDB python package from https://pypi.org/[PyPI repository], you
 first need to install on your system some development libraries required by
 RacksDB external dependencies. For example, on Debian/Ubuntu:
 
-[source,console]
-----
-$ sudo apt install libcairo2-dev libgirepository1.0-dev
-----
+include::partial$pip-deps.adoc[]
 
 To install RacksDB python package from https://pypi.org/[PyPI repository], run
 the following command:
@@ -324,10 +321,7 @@ Some development libraries are required to install RacksDB external dependencies
 from https://pypi.org/[PyPI repository]. For example on Debian/Ubuntu, run this
 command to install you these development libraries:
 
-[source,console]
-----
-$ sudo apt install libcairo2-dev libgirepository1.0-dev
-----
+include::partial$pip-deps.adoc[]
 
 To install RacksDB from sources, run this command in the source tree directory:
 

--- a/docs/modules/install/partials/pip-deps.adoc
+++ b/docs/modules/install/partials/pip-deps.adoc
@@ -1,0 +1,17 @@
+[source,console]
+----
+$ sudo apt install libcairo2-dev libgirepository-2.0-dev
+----
+
+[CAUTION]
+====
+On Debian _« bookworm »_, `libgirepository-2.0-dev` package is not
+available. As a workaround, you can install `libgirepository1.0-dev` instead
+with an older version of PyGObject in your virtual environment:
+
+[source,console]
+----
+$ sudo apt install libcairo2-dev libgirepository1.0-dev
+$ pip install "PyGObject<3.43.0"
+----
+====


### PR DESCRIPTION
Fix system dependency package name (libgirepository1.0-dev is now replaced by libgirepository-2.0-dev) in quickstart guide when installing from PyPI and from source. Also add a caution note for Debian bookworm.

fix #131